### PR TITLE
disallow the stateController from overwriting the local value

### DIFF
--- a/dist/angular-country-state-select.js
+++ b/dist/angular-country-state-select.js
@@ -336,7 +336,7 @@ function stateDirective(src,$timeout) {
         replace: true,
         scope: {
             country: '@',
-            ngModel: '='
+            ngModel: '@'
         },
         controller: stateController,
         controllerAs: 'sc',


### PR DESCRIPTION
Bind the stateController `scope.ngModel` to the evaluated value of the DOM attribute rather than the model object itself. This prevents the stateController from overwriting the local model value when loading fresh data into the local model.
